### PR TITLE
update VK link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Information:
  [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=lightez)](https://github.com/lightez/github-readme-stats) 
   
  <!---Пример кода--> 
- [![Typing SVG](https://readme-typing-svg.herokuapp.com?color=%2336BCF7&lines=My+VK:+https://vk.com/eee_dev)](https://git.io/typing-svg)
+ [![Typing SVG](https://readme-typing-svg.herokuapp.com?color=%2336BCF7&lines=My+VK:+https://vk.com/eee_dev)](https://vk.com/eee_dev)


### PR DESCRIPTION
redirect to https://vk.com/eee_dev instead of https://git.io/typing-svg